### PR TITLE
Add the queryString and the variables to the onError callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Relay.injectNetworkLayer(
   new RelayLocalSchema.NetworkLayer({
     schema,
     rootValue: "foo",
-    onError: errors => console.log(errors)
+    onError: (errors, queryString, variables) => {
+      console.log(errors, queryString, variables);
+    },
   })
 );
 ```

--- a/src/NetworkLayer.js
+++ b/src/NetworkLayer.js
@@ -24,11 +24,13 @@ export default class NetworkLayer {
   }
 
   async _executeRequest(requestType, request) {
+    const queryString = request.getQueryString();
+    const variables = request.getVariables();
     const {data, errors} = await graphql(
       this._schema,
-      request.getQueryString(),
+      queryString,
       this._rootValue,
-      request.getVariables()
+      variables
     );
 
     if (errors) {
@@ -38,7 +40,7 @@ export default class NetworkLayer {
         formatRequestErrors(request, errors)
       ));
       if (this._onError) {
-        this._onError(errors);
+        this._onError(errors, queryString, variables);
       }
       return;
     }


### PR DESCRIPTION
What do you think about making the original query string and variables available to the `onError` callback?