### PR TITLE
Update onError API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Relay.injectNetworkLayer(
   new RelayLocalSchema.NetworkLayer({
     schema,
     rootValue: "foo",
-    onError: errors => console.log(errors)
+    onError: (errors, request) => console.log(errors, request)
   })
 );
 ```

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "peerDependencies": {
     "graphql": "^0.4.2",
-    "react-relay": "^0.2.0 || ^0.3.1"
+    "react-relay": "^0.3.1"
   },
   "dependencies": {
     "babel-runtime": "^5.8.20"

--- a/src/NetworkLayer.js
+++ b/src/NetworkLayer.js
@@ -38,7 +38,7 @@ export default class NetworkLayer {
         formatRequestErrors(request, errors)
       ));
       if (this._onError) {
-        this._onError(errors);
+        this._onError(errors, request);
       }
       return;
     }


### PR DESCRIPTION
@steveluscher

Per https://github.com/relay-tools/relay-local-schema/pull/3#issuecomment-139701031.

Or would it make more sense to do `(request, errors)` rather than `(errors, request)`? This would be v0.2.0 for dropping the Relay v0.2.x peer dependency anyway.