### PR TITLE
Remove GraphQL and Relay from devDependencies; leave them in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "babel-eslint": "^4.1.1",
     "eslint": "^1.4.1",
     "eslint-config-airbnb": "0.0.8",
-    "eslint-plugin-react": "^3.3.2",
-    "graphql": "^0.4.3",
-    "react-relay": "^0.3.1"
+    "eslint-plugin-react": "^3.3.2"
   },
   "peerDependencies": {
     "graphql": "^0.4.2",


### PR DESCRIPTION
I think this is how you avoid having two instances of GraphQL (and hence schema errors).