### PR TITLE
Added source property when a errors is returned from graphql

### DIFF
--- a/src/NetworkLayer.js
+++ b/src/NetworkLayer.js
@@ -1,6 +1,6 @@
 import { graphql } from 'graphql';
 
-import formatRequestErrors from './__forks__/formatRequestErrors';
+import createRequestError from './__forks__/createRequestError';
 
 export default class NetworkLayer {
   constructor({ schema, rootValue, contextValue, onError }) {
@@ -31,20 +31,17 @@ export default class NetworkLayer {
       this.rootValue,
       this.context,
       request.getVariables()
-    ).then(({ data, errors }) => {
-      if (errors) {
-        request.reject(new Error(
-          `Failed to execute ${requestType} \`${request.getDebugName()}\` for ` +
-          `the following reasons:\n\n${formatRequestErrors(request, errors)}`
-        ));
+    ).then((payload) => {
+      if (payload.errors) {
+        request.reject(createRequestError(request, requestType, payload));
         if (this.onError) {
-          this.onError(errors, request);
+          this.onError(payload.errors, request);
         }
 
         return;
       }
 
-      request.resolve({ response: data });
+      request.resolve({ response: payload.data });
     });
   }
 

--- a/src/__forks__/createRequestError.js
+++ b/src/__forks__/createRequestError.js
@@ -1,0 +1,10 @@
+import formatRequestErrors from './formatRequestErrors';
+
+export default function createRequestError(request, requestType, payload) {
+  const error = new Error(
+    `Failed to execute ${requestType} \`${request.getDebugName()}\` for ` +
+    `the following reasons:\n\n${formatRequestErrors(request, payload.errors)}`
+  );
+  error.source = payload;
+  return error;
+}

--- a/src/__forks__/createRequestError.js
+++ b/src/__forks__/createRequestError.js
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/**
+ * Formats an error response from GraphQL server request.
+ */
 import formatRequestErrors from './formatRequestErrors';
 
 export default function createRequestError(request, requestType, payload) {

--- a/test/NetworkLayer.test.js
+++ b/test/NetworkLayer.test.js
@@ -69,6 +69,42 @@ describe('NetworkLayer', () => {
 
       ReactTestUtils.renderIntoDocument(<Component />);
     });
+
+    it('should fail', done => {
+      function Widget() {
+        return (<div />);
+      }
+
+      const WidgetContainer = Relay.createContainer(Widget, {
+        fragments: {
+          widget: () => Relay.QL`
+            fragment on Widget {
+              name
+            }
+          `,
+        },
+      });
+
+      const widgetQueryConfig = {
+        name: 'WidgetQueryConfig',
+        queries: {
+          widget: () => Relay.QL`query { invalid }`,
+        },
+        params: {},
+      };
+
+      ReactTestUtils.renderIntoDocument(<Relay.Renderer
+        Container={WidgetContainer}
+        queryConfig={widgetQueryConfig}
+        environment={environment}
+        render={({ error }) => {
+          if (error) {
+            expect(error.source.errors[0].message).to.equal('Always fail');
+            done();
+          }
+        }}
+      />);
+    });
   });
 
   describe('mutation', () => {

--- a/test/fixtures/schema.js
+++ b/test/fixtures/schema.js
@@ -36,6 +36,12 @@ const query = new GraphQLObjectType({
       type: Widget,
       resolve: () => widget,
     },
+    invalid: {
+      type: Widget,
+      resolve: () => {
+        throw Error('Always fail');
+      },
+    },
   },
 });
 


### PR DESCRIPTION
In the `RelayDefaultNetworkLayer` when a error returns from graphql a source property is added to the response, allowing a client to get the error returned from server, see https://github.com/facebook/relay/blob/master/src/network-layer/default/RelayDefaultNetworkLayer.js#L213.